### PR TITLE
fix: use the main prop for the application entry point.

### DIFF
--- a/greeting-service/package.json
+++ b/greeting-service/package.json
@@ -11,11 +11,12 @@
     "coverage": "nyc npm test",
     "coveralls": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
     "dependencyCheck": "szero . --ci",
-    "start": "PORT=8080 node ./bin/www",
+    "start": "node .",
     "prepublish": "license-reporter report -s",
     "openshift": "nodeshift --strictSSL=false --dockerImage=registry.access.redhat.com/rhoar-nodejs/nodejs-8 --metadata.out=nodeshift-metadata.json",
     "postinstall": "license-reporter report -s && license-reporter save -s --xml licenses.xml"
   },
+  "main": "./bin/www",
   "repository": {
     "type": "git",
     "url": "git://github.com/bucharest-gold/nodejs-circuit-breaker-redhat.git"

--- a/name-service/bin/www
+++ b/name-service/bin/www
@@ -18,7 +18,7 @@
  */
 'use strict';
 const server = require('../app');
-const port = normalizePort(process.env.PORT || '8081');
+const port = normalizePort(process.env.PORT || '8080');
 
 server.on('error', onError);
 

--- a/name-service/package.json
+++ b/name-service/package.json
@@ -1,7 +1,6 @@
 {
   "name": "nodejs-circuit-breaker-redhat-name",
   "version": "1.1.1",
-  "main": "false",
   "author": "Red Hat, Inc.",
   "license": "Apache-2.0",
   "scripts": {
@@ -14,8 +13,9 @@
     "prepublish": "license-reporter report -s",
     "openshift": "nodeshift --strictSSL=false --dockerImage=registry.access.redhat.com/rhoar-nodejs/nodejs-8 --metadata.out=nodeshift-metadata.json",
     "postinstall": "license-reporter report -s && license-reporter save -s --xml licenses.xml",
-    "start": "PORT=8080 node ./bin/www"
+    "start": "node ."
   },
+  "main": "./bin/www",
   "repository": {
     "type": "git",
     "url": "git://github.com/bucharest-gold/nodejs-circuit-breaker-redhat.git"


### PR DESCRIPTION
npm start will now look at the main property for the entry point.  Port 8080 is now set as the default port instead of 3000.   This is a fix related to bucharest-gold/centos7-s2i-nodejs#33\#issuecomment-382587104.

fixes #11